### PR TITLE
fix: subuser and api key now mostly work

### DIFF
--- a/sdk/errors.go
+++ b/sdk/errors.go
@@ -16,3 +16,8 @@ var (
 	ErrTemplateVersionNameRequired    = errors.New("a template version name is required")
 	ErrTemplateVersionSubjectRequired = errors.New("a template version subject is required")
 )
+
+type RequestError struct {
+	StatusCode int
+	Err        error
+}

--- a/sendgrid/resource_sendgrid_api_key.go
+++ b/sendgrid/resource_sendgrid_api_key.go
@@ -94,8 +94,8 @@ func resourceSendgridAPIKeyCreate(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	apiKey, err := c.CreateAPIKey(name, scopes)
-	if err != nil {
-		return diag.FromErr(err)
+	if err.Err != nil {
+		return diag.FromErr(err.Err)
 	}
 
 	d.SetId(apiKey.ID)
@@ -111,8 +111,8 @@ func resourceSendgridAPIKeyRead(_ context.Context, d *schema.ResourceData, m int
 	c.OnBehalfOf = d.Get("sub_user_on_behalf_of").(string)
 
 	apiKey, err := c.ReadAPIKey(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
+	if err.Err != nil {
+		return diag.FromErr(err.Err)
 	}
 
 	//nolint:errcheck
@@ -154,8 +154,8 @@ func resourceSendgridAPIKeyUpdate(ctx context.Context, d *schema.ResourceData, m
 		a.Scopes = scopes
 	}
 
-	if _, err := c.UpdateAPIKey(d.Id(), a.Name, a.Scopes); err != nil {
-		return diag.FromErr(err)
+	if _, err := c.UpdateAPIKey(d.Id(), a.Name, a.Scopes); err.Err != nil {
+		return diag.FromErr(err.Err)
 	}
 
 	return resourceSendgridAPIKeyRead(ctx, d, m)

--- a/sendgrid/resource_sendgrid_api_key.go
+++ b/sendgrid/resource_sendgrid_api_key.go
@@ -167,8 +167,8 @@ func resourceSendgridAPIKeyDelete(_ context.Context, d *schema.ResourceData, m i
 	c.OnBehalfOf = d.Get("sub_user_on_behalf_of").(string)
 
 	_, err := c.DeleteAPIKey(d.Id())
-	if err != nil {
-		return diag.FromErr(err)
+	if err.Err != nil {
+		return diag.FromErr(err.Err)
 	}
 
 	return nil

--- a/sendgrid/resource_sendgrid_api_key.go
+++ b/sendgrid/resource_sendgrid_api_key.go
@@ -89,10 +89,6 @@ func resourceSendgridAPIKeyCreate(ctx context.Context, d *schema.ResourceData, m
 		scopes = append(scopes, "sender_verification_eligible")
 	}
 
-	if ok := scopeInScopes(scopes, "2fa_required"); !ok {
-		scopes = append(scopes, "2fa_required")
-	}
-
 	apiKey, err := c.CreateAPIKey(name, scopes)
 	if err.Err != nil {
 		return diag.FromErr(err.Err)

--- a/sendgrid/resource_sendgrid_api_key_test.go
+++ b/sendgrid/resource_sendgrid_api_key_test.go
@@ -40,8 +40,8 @@ func testAccCheckSendgridAPIKeyDestroy(s *terraform.State) error {
 		apiKeyID := rs.Primary.ID
 
 		_, err := c.DeleteAPIKey(apiKeyID)
-		if err != nil {
-			return err
+		if err.Err != nil {
+			return err.Err
 		}
 	}
 

--- a/sendgrid/resource_sendgrid_subuser.go
+++ b/sendgrid/resource_sendgrid_subuser.go
@@ -21,7 +21,6 @@ package sendgrid
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -31,7 +30,9 @@ import (
 	sendgrid "github.com/trois-six/terraform-provider-sendgrid/sdk"
 )
 
-var ErrSubUserNotFound = errors.New("subUser wasn't found")
+func subUserNotFound(name string) error {
+	return fmt.Errorf("subUser %s wasn't found", name)
+}
 
 func resourceSendgridSubuser() *schema.Resource {
 	return &schema.Resource{
@@ -153,7 +154,7 @@ func resourceSendgridSubuserRead(_ context.Context, d *schema.ResourceData, m in
 	}
 
 	if len(subUser) == 0 {
-		return diag.FromErr(ErrSubUserNotFound)
+		return diag.FromErr(subUserNotFound(d.Id()))
 	}
 
 	//nolint:errcheck

--- a/sendgrid/resource_sendgrid_subuser.go
+++ b/sendgrid/resource_sendgrid_subuser.go
@@ -21,6 +21,7 @@ package sendgrid
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -30,8 +31,10 @@ import (
 	sendgrid "github.com/trois-six/terraform-provider-sendgrid/sdk"
 )
 
+var ErrSubUserNotFound = errors.New("subUser wasn't found")
+
 func subUserNotFound(name string) error {
-	return fmt.Errorf("subUser %s wasn't found", name)
+	return fmt.Errorf("%w: %s", ErrSubUserNotFound, name)
 }
 
 func resourceSendgridSubuser() *schema.Resource {


### PR DESCRIPTION
Still debugging:

```
Error: failed creating apiKey, status: 500, response: {"errors":[{"field":null,"message":"internal server error"}]}

  on main.tf line 45, in resource "sendgrid_api_key" "api_key_sub_user_1":
  45: resource "sendgrid_api_key" "api_key_sub_user_1" {
```

