### PR TITLE
Feat: Add SSO resources

### DIFF
--- a/docs/resources/sso_certificate.md
+++ b/docs/resources/sso_certificate.md
@@ -1,0 +1,46 @@
+# sendgrid_sso_certificate
+
+Provide a resource to manage SSO certificates.
+
+## Example Usage
+
+```hcl
+resource "sendgrid_sso_integration" "sso" {
+	name    = "IdP"
+	enabled = true
+
+	signin_url  = "https://idp.com/signin"
+	signout_url = "https://idp.com/signout"
+	entity_id   = "https://idp.com/12345"
+}
+
+resource "sendgrid_sso_certificate" "cert" {
+	integration_id = sendgrid_sso_integration.sso.id
+	public_certificate = <<EOF
+-----BEGIN CERTIFICATE-----
+...
+EOF
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `integration_id` - (Required) An ID that matches an existing SSO integration.
+* `public_certificate` - (Required) This public certificate allows SendGrid to verify that
+					SAML requests it receives are signed by an IdP that it recognizes.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `enabled` - Indicates if the certificate is enabled.
+
+
+## Import
+
+An SSO certificate can be imported, e.g.
+```sh
+$ terraform import sendgrid_sso_certificate.cert <certificate-id>
+```

--- a/docs/resources/sso_certificate.md
+++ b/docs/resources/sso_certificate.md
@@ -31,12 +31,6 @@ The following arguments are supported:
 * `public_certificate` - (Required) This public certificate allows SendGrid to verify that
 					SAML requests it receives are signed by an IdP that it recognizes.
 
-## Attributes Reference
-
-In addition to all arguments above, the following attributes are exported:
-
-* `enabled` - Indicates if the certificate is enabled.
-
 
 ## Import
 

--- a/docs/resources/sso_integration.md
+++ b/docs/resources/sso_integration.md
@@ -1,0 +1,49 @@
+# sendgrid_sso_integration
+
+Provide a resource to manage SSO integrations. Note that to finalize the integration, a user must click through the 'enable integration' workflow once after supplying all required fields including an SSO certificate via `aws_sso_certificate`.
+
+## Example Usage
+
+```hcl
+resource "sendgrid_sso_integration" "sso" {
+	name    = "IdP"
+	enabled = false
+
+	signin_url  = "https://idp.com/signin"
+	signout_url = "https://idp.com/signout"
+	entity_id   = "https://idp.com/12345"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `enabled` - (Required) Indicates if the integration is enabled.
+* `name` - (Required) The name of the integration.
+* `entity_id` - (Optional) An identifier provided by your IdP to identify Twilio SendGrid in the SAML interaction.
+					This is called the 'SAML Issuer ID' in the Twilio SendGrid UI.
+* `signin_url` - (Optional) The IdP's SAML POST endpoint. This endpoint should receive requests
+					and initiate an SSO login flow. This is called the 'Embed Link' in the Twilio SendGrid UI.
+* `signout_url` - (Optional) This URL is relevant only for an IdP-initiated authentication flow.
+					If a user authenticates from their IdP, this URL will return them to their IdP when logging out.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `audience_url` - The URL where your IdP should POST its SAML response.
+					This is the Twilio SendGrid URL that is responsible for receiving and parsing a SAML assertion.
+					This is the same URL as the Single Sign-On URL when using SendGrid.
+* `completed_integration` - Indicates if the integration is complete.
+* `single_signon_url` - The URL where your IdP should POST its SAML response.
+					This is the Twilio SendGrid URL that is responsible for receiving and parsing a SAML assertion.
+					This is the same URL as the Audience URL when using SendGrid.
+
+
+## Import
+
+A SSO integration can be imported, e.g.
+```sh
+$ terraform import sendgrid_sso_integration.sso <integration-id>
+```

--- a/docs/resources/sso_integration.md
+++ b/docs/resources/sso_integration.md
@@ -1,6 +1,9 @@
 # sendgrid_sso_integration
 
-Provide a resource to manage SSO integrations. Note that to finalize the integration, a user must click through the 'enable integration' workflow once after supplying all required fields including an SSO certificate via `aws_sso_certificate`.
+Provide a resource to manage SSO integrations.
+
+**Note** To finalize the integration, a user must click through the 'enable integration'
+workflow once after supplying all required fields including an SSO certificate via `aws_sso_certificate`.
 
 ## Example Usage
 

--- a/sdk/errors.go
+++ b/sdk/errors.go
@@ -90,6 +90,24 @@ var (
 
 	// ErrSubUserPassword should be empty.
 	ErrSubUserPassword = errors.New("new password must be non empty")
+
+	// ErrSSOIntegrationMissingField error displayed when a required SSO integration field is not specified.
+	ErrSSOIntegrationMissingField = errors.New("SSO integration field is missing")
+
+	// ErrFailedCreatingSSOIntegration error displayed when an SSO integration creation request fails.
+	ErrFailedCreatingSSOIntegration = errors.New("failed to create SSO integration")
+
+	// ErrFailedUpdatingSSOIntegration error displayed when an SSO integration update request fails.
+	ErrFailedUpdatingSSOIntegration = errors.New("failed to update SSO integration")
+
+	// ErrSSOCertificateMissingField error displayed when a required SSO certificate field is not specified.
+	ErrSSOCertificateMissingField = errors.New("SSO certificate field is missing")
+
+	// ErrFailedCreatingSSOCertificate error displayed when an SSO certificate creation request fails.
+	ErrFailedCreatingSSOCertificate = errors.New("failed to create SSO certificate")
+
+	// ErrFailedUpdatingSSOCertificate error displayed when an SSO certificate update request fails.
+	ErrFailedUpdatingSSOCertificate = errors.New("failed to update SSO certificate")
 )
 
 // RequestError struct permits to embed to return the statucode and the error to the parent function.

--- a/sdk/sso_certificate.go
+++ b/sdk/sso_certificate.go
@@ -1,0 +1,185 @@
+package sendgrid
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// SSOCertificate maps a public certificate to an SSO integration,
+// allowing the SSO integration to verify SAML requests from an IdP.
+type SSOCertificate struct {
+	PublicCertificate string `json:"public_certificate"` //nolint:tagliatelle
+	IntegrationID     string `json:"integration_id"`     //nolint:tagliatelle
+	ID                int32  `json:"id,omitempty"`
+	Enabled           bool   `json:"enabled,omitempty"`
+}
+
+// CreateSSOCertificate creates an SSO certificate and returns it.
+func (c Client) CreateSSOCertificate(
+	publicCertificate string,
+	integrationID string,
+) (*SSOCertificate, RequestError) {
+	if integrationID == "" {
+		return nil, RequestError{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("%w: integration_id", ErrSSOCertificateMissingField),
+		}
+	}
+
+	if publicCertificate == "" {
+		return nil, RequestError{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("%w: public_certificate", ErrSSOCertificateMissingField),
+		}
+	}
+
+	respBody, statusCode, err := c.Post("POST", "/sso/certificates", SSOCertificate{
+		IntegrationID:     integrationID,
+		PublicCertificate: publicCertificate,
+	})
+	if err != nil {
+		return nil, RequestError{
+			StatusCode: http.StatusInternalServerError,
+			Err:        fmt.Errorf("failed to create SSO certificate: %w", err),
+		}
+	}
+
+	if statusCode >= http.StatusMultipleChoices {
+		return nil, RequestError{
+			StatusCode: statusCode,
+			Err:        fmt.Errorf("%w, status: %d, response: %s", ErrFailedCreatingSSOCertificate, statusCode, respBody),
+		}
+	}
+
+	return parseSSOCertificate(respBody)
+}
+
+// ReadSSOCertificate retrieves an SSO certificate by ID.
+func (c Client) ReadSSOCertificate(id string) (*SSOCertificate, RequestError) {
+	if id == "" {
+		return nil, RequestError{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("%w: id", ErrSSOCertificateMissingField),
+		}
+	}
+
+	respBody, _, err := c.Get("GET", fmt.Sprintf("/sso/certificates/%s", id))
+	if err != nil {
+		return nil, RequestError{
+			StatusCode: http.StatusInternalServerError,
+			Err:        err,
+		}
+	}
+
+	return parseSSOCertificate(respBody)
+}
+
+// UpdateSSOCertificate updates an existing SSO certificate by ID.
+func (c Client) UpdateSSOCertificate(
+	id string,
+	publicCertificate string,
+	integrationID string,
+) (*SSOCertificate, RequestError) {
+	if id == "" {
+		return nil, RequestError{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("%w: id", ErrSSOCertificateMissingField),
+		}
+	}
+
+	if integrationID == "" {
+		return nil, RequestError{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("%w: integration_id", ErrSSOCertificateMissingField),
+		}
+	}
+
+	if publicCertificate == "" {
+		return nil, RequestError{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("%w: public_certificate", ErrSSOCertificateMissingField),
+		}
+	}
+
+	respBody, statusCode, err := c.Post("PATCH", fmt.Sprintf("/sso/certificates/%s", id), SSOCertificate{
+		IntegrationID:     integrationID,
+		PublicCertificate: publicCertificate,
+	})
+	if err != nil {
+		return nil, RequestError{
+			StatusCode: http.StatusInternalServerError,
+			Err:        fmt.Errorf("failed to update SSO certificate: %w", err),
+		}
+	}
+
+	if statusCode >= http.StatusMultipleChoices {
+		return nil, RequestError{
+			StatusCode: statusCode,
+			Err:        fmt.Errorf("%w, status: %d, response: %s", ErrFailedUpdatingSSOCertificate, statusCode, respBody),
+		}
+	}
+
+	return parseSSOCertificate(respBody)
+}
+
+// DeleteSSOCertificate deletes an SSO certificate by ID.
+func (c Client) DeleteSSOCertificate(id string) (bool, RequestError) {
+	if id == "" {
+		return false, RequestError{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("%w: id", ErrSSOCertificateMissingField),
+		}
+	}
+
+	if _, statusCode, err := c.Get("DELETE", fmt.Sprintf("/sso/certificates/%s", id)); statusCode > 299 || err != nil {
+		return false, RequestError{
+			StatusCode: http.StatusInternalServerError,
+			Err:        fmt.Errorf("failed deleting SSO integration: %w", err),
+		}
+	}
+
+	return true, RequestError{
+		StatusCode: http.StatusOK,
+		Err:        nil,
+	}
+}
+
+// ListSSOCertificates retrieves all existing SSO certificates.
+func (c Client) ListSSOCertificates() ([]*SSOCertificate, RequestError) {
+	respBody, statusCode, err := c.Get("GET", "/sso/certificates")
+	if err != nil || statusCode >= 300 {
+		return nil, RequestError{
+			StatusCode: statusCode,
+			Err:        err,
+		}
+	}
+
+	return parseSSOCertificates(respBody)
+}
+
+func parseSSOCertificate(respBody string) (*SSOCertificate, RequestError) {
+	var body SSOCertificate
+
+	if err := json.Unmarshal([]byte(respBody), &body); err != nil {
+		return nil, RequestError{
+			StatusCode: http.StatusInternalServerError,
+			Err:        fmt.Errorf("failed to parse SSO certificate: %w", err),
+		}
+	}
+
+	return &body, RequestError{StatusCode: http.StatusOK, Err: nil}
+}
+
+func parseSSOCertificates(respBody string) ([]*SSOCertificate, RequestError) {
+	var body []*SSOCertificate
+
+	if err := json.Unmarshal([]byte(respBody), &body); err != nil {
+		return nil, RequestError{
+			StatusCode: http.StatusInternalServerError,
+			Err:        fmt.Errorf("failed to parse SSO certificates: %w", err),
+		}
+	}
+
+	return body, RequestError{StatusCode: http.StatusOK, Err: nil}
+}

--- a/sdk/sso_certificate.go
+++ b/sdk/sso_certificate.go
@@ -12,7 +12,6 @@ type SSOCertificate struct {
 	PublicCertificate string `json:"public_certificate"` //nolint:tagliatelle
 	IntegrationID     string `json:"integration_id"`     //nolint:tagliatelle
 	ID                int32  `json:"id,omitempty"`
-	Enabled           bool   `json:"enabled,omitempty"`
 }
 
 // CreateSSOCertificate creates an SSO certificate and returns it.

--- a/sdk/sso_integration.go
+++ b/sdk/sso_integration.go
@@ -1,0 +1,187 @@
+package sendgrid
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// SSOIntegration is a Sendgrid SSO configuration set.
+type SSOIntegration struct {
+	CompletedIntegration bool   `json:"completed_integration,omitempty"` //nolint:tagliatelle
+	Enabled              bool   `json:"enabled"`
+	Name                 string `json:"name"`
+	SignInURL            string `json:"signin_url"`  //nolint:tagliatelle
+	SignOutURL           string `json:"signout_url"` //nolint:tagliatelle
+	EntityID             string `json:"entity_id"`   //nolint:tagliatelle
+	ID                   string `json:"id,omitempty"`
+	SingleSignOnURL      string `json:"single_signon_url,omitempty"` //nolint:tagliatelle
+	AudienceURL          string `json:"audience_url,omitempty"`      //nolint:tagliatelle
+}
+
+// CreateSSOIntegration creates an SSO integration and returns it.
+func (c Client) CreateSSOIntegration(
+	name string,
+	enabled bool,
+	signInURL string,
+	signOutURL string,
+	entityID string,
+) (*SSOIntegration, RequestError) {
+	if name == "" {
+		return nil, RequestError{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("%w: name", ErrSSOIntegrationMissingField),
+		}
+	}
+
+	respBody, statusCode, err := c.Post("POST", "/sso/integrations", SSOIntegration{
+		Name:       name,
+		Enabled:    enabled,
+		SignInURL:  signInURL,
+		SignOutURL: signOutURL,
+		EntityID:   entityID,
+	})
+	if err != nil {
+		return nil, RequestError{
+			StatusCode: http.StatusInternalServerError,
+			Err:        fmt.Errorf("failed to create SSO integration: %w", err),
+		}
+	}
+
+	if statusCode >= http.StatusMultipleChoices {
+		return nil, RequestError{
+			StatusCode: statusCode,
+			Err:        fmt.Errorf("%w, status: %d, response: %s", ErrFailedCreatingSSOIntegration, statusCode, respBody),
+		}
+	}
+
+	return parseSSOIntegration(respBody)
+}
+
+// ReadSSOIntegration retrieves an SSO integration by ID.
+func (c Client) ReadSSOIntegration(id string) (*SSOIntegration, RequestError) {
+	if id == "" {
+		return nil, RequestError{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("%w: id", ErrSSOIntegrationMissingField),
+		}
+	}
+
+	respBody, _, err := c.Get("GET", fmt.Sprintf("/sso/integrations/%s", id))
+	if err != nil {
+		return nil, RequestError{
+			StatusCode: http.StatusInternalServerError,
+			Err:        err,
+		}
+	}
+
+	return parseSSOIntegration(respBody)
+}
+
+// UpdateSSOIntegration updates an existing SSO integration by ID.
+func (c Client) UpdateSSOIntegration(
+	id string,
+	name string,
+	enabled bool,
+	signInURL string,
+	signOutURL string,
+	entityID string,
+) (*SSOIntegration, RequestError) {
+	if id == "" {
+		return nil, RequestError{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("%w: id", ErrSSOIntegrationMissingField),
+		}
+	}
+
+	if name == "" {
+		return nil, RequestError{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("%w: name", ErrSSOIntegrationMissingField),
+		}
+	}
+
+	respBody, statusCode, err := c.Post("PATCH", fmt.Sprintf("/sso/integrations/%s", id), SSOIntegration{
+		Name:       name,
+		Enabled:    enabled,
+		SignInURL:  signInURL,
+		SignOutURL: signOutURL,
+		EntityID:   entityID,
+	})
+	if err != nil {
+		return nil, RequestError{
+			StatusCode: http.StatusInternalServerError,
+			Err:        err,
+		}
+	}
+
+	if statusCode >= http.StatusMultipleChoices {
+		return nil, RequestError{
+			StatusCode: statusCode,
+			Err:        fmt.Errorf("%w, status: %d, response: %s", ErrFailedUpdatingSSOIntegration, statusCode, respBody),
+		}
+	}
+
+	return parseSSOIntegration(respBody)
+}
+
+// DeleteSSOIntegration deletes an SSO integration by ID.
+func (c Client) DeleteSSOIntegration(id string) (bool, RequestError) {
+	if id == "" {
+		return false, RequestError{
+			StatusCode: http.StatusBadRequest,
+			Err:        fmt.Errorf("%w: id", ErrSSOIntegrationMissingField),
+		}
+	}
+
+	if _, statusCode, err := c.Get("DELETE", fmt.Sprintf("/sso/integrations/%s", id)); statusCode > 299 || err != nil {
+		return false, RequestError{
+			StatusCode: http.StatusInternalServerError,
+			Err:        fmt.Errorf("failed to delete SSO integration: %w", err),
+		}
+	}
+
+	return true, RequestError{
+		StatusCode: http.StatusOK,
+		Err:        nil,
+	}
+}
+
+// ListSSOIntegrations returns a list of SSO integrations.
+func (c Client) ListSSOIntegrations() ([]*SSOIntegration, RequestError) {
+	respBody, statusCode, err := c.Get("GET", "/sso/integrations")
+	if err != nil || statusCode >= 300 {
+		return nil, RequestError{
+			StatusCode: statusCode,
+			Err:        err,
+		}
+	}
+
+	return parseSSOIntegrations(respBody)
+}
+
+func parseSSOIntegration(respBody string) (*SSOIntegration, RequestError) {
+	var body SSOIntegration
+
+	if err := json.Unmarshal([]byte(respBody), &body); err != nil {
+		return nil, RequestError{
+			StatusCode: http.StatusInternalServerError,
+			Err:        fmt.Errorf("failed to parse SSO integration: %w", err),
+		}
+	}
+
+	return &body, RequestError{StatusCode: http.StatusOK, Err: nil}
+}
+
+func parseSSOIntegrations(respBody string) ([]*SSOIntegration, RequestError) {
+	var body []*SSOIntegration
+
+	if err := json.Unmarshal([]byte(respBody), &body); err != nil {
+		return nil, RequestError{
+			StatusCode: http.StatusInternalServerError,
+			Err:        fmt.Errorf("failed to parse SSO integrations: %w", err),
+		}
+	}
+
+	return body, RequestError{StatusCode: http.StatusOK, Err: nil}
+}

--- a/sendgrid/provider.go
+++ b/sendgrid/provider.go
@@ -77,6 +77,8 @@ func Provider() *schema.Provider {
 			"sendgrid_event_webhook":         resourceSendgridEventWebhook(),
 			"sendgrid_domain_authentication": resourceSendgridDomainAuthentication(),
 			"sendgrid_link_branding":         resourceSendgridLinkBranding(),
+			"sendgrid_sso_integration":       resourceSendgridSSOIntegration(),
+			"sendgrid_sso_certificate":       resourceSendgridSSOCertificate(),
 		},
 
 		ConfigureContextFunc: providerConfigure,

--- a/sendgrid/resource_sendgrid_sso_certificate.go
+++ b/sendgrid/resource_sendgrid_sso_certificate.go
@@ -57,11 +57,6 @@ func resourceSendgridSSOCertificate() *schema.Resource {
 				Description: "An ID that matches an existing SSO integration.",
 				Required:    true,
 			},
-			"enabled": {
-				Type:        schema.TypeBool,
-				Description: "Indicates if the certificate is enabled.",
-				Computed:    true,
-			},
 		},
 	}
 }

--- a/sendgrid/resource_sendgrid_sso_certificate.go
+++ b/sendgrid/resource_sendgrid_sso_certificate.go
@@ -1,0 +1,134 @@
+/*
+Provide a resource to manage SSO certificates.
+Example Usage
+```hcl
+resource "sendgrid_sso_integration" "sso" {
+	name    = "IdP"
+	enabled = true
+
+	signin_url  = "https://idp.com/signin"
+	signout_url = "https://idp.com/signout"
+	entity_id   = "https://idp.com/12345"
+}
+
+resource "sendgrid_sso_certificate" "cert" {
+	integration_id = sendgrid_sso_integration.sso.id
+	public_certificate = <<EOF
+-----BEGIN CERTIFICATE-----
+...
+EOF
+}
+```
+Import
+An SSO certificate can be imported, e.g.
+```sh
+$ terraform import sendgrid_sso_certificate.cert <certificate-id>
+```
+*/
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	sendgrid "github.com/trois-six/terraform-provider-sendgrid/sdk"
+)
+
+func resourceSendgridSSOCertificate() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSendgridSSOCertificateCreate,
+		ReadContext:   resourceSendgridSSOCertificateRead,
+		UpdateContext: resourceSendgridSSOCertificateUpdate,
+		DeleteContext: resourceSendgridSSOCertificateDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"public_certificate": {
+				Type: schema.TypeString,
+				Description: `This public certificate allows SendGrid to verify that
+					SAML requests it receives are signed by an IdP that it recognizes.`,
+				Required: true,
+			},
+			"integration_id": {
+				Type:        schema.TypeString,
+				Description: "An ID that matches an existing SSO integration.",
+				Required:    true,
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Description: "Indicates if the certificate is enabled.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func resourceSendgridSSOCertificateCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*sendgrid.Client)
+
+	publicCertificate := d.Get("public_certificate").(string)
+	integrationID := d.Get("integration_id").(string)
+
+	apiKeyStruct, err := sendgrid.RetryOnRateLimit(ctx, d, func() (interface{}, sendgrid.RequestError) {
+		return c.CreateSSOCertificate(publicCertificate, integrationID)
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	certificate := apiKeyStruct.(*sendgrid.SSOCertificate)
+
+	d.SetId(fmt.Sprint(certificate.ID))
+
+	return resourceSendgridSSOCertificateRead(ctx, d, m)
+}
+
+func resourceSendgridSSOCertificateRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*sendgrid.Client)
+
+	certificate, requestErr := c.ReadSSOCertificate(d.Id())
+
+	if requestErr.Err != nil {
+		return diag.FromErr(requestErr.Err)
+	}
+
+	//nolint:errcheck
+	d.Set("public_certificate", certificate.PublicCertificate)
+	//nolint:errcheck
+	d.Set("integration_id", certificate.IntegrationID)
+
+	return nil
+}
+
+func resourceSendgridSSOCertificateUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*sendgrid.Client)
+
+	id := d.Id()
+	publicCertificate := d.Get("public_certificate").(string)
+	integrationID := d.Get("integration_id").(string)
+
+	_, err := sendgrid.RetryOnRateLimit(ctx, d, func() (interface{}, sendgrid.RequestError) {
+		return c.UpdateSSOCertificate(id, publicCertificate, integrationID)
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceSendgridSSOCertificateRead(ctx, d, m)
+}
+
+func resourceSendgridSSOCertificateDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*sendgrid.Client)
+
+	_, err := sendgrid.RetryOnRateLimit(ctx, d, func() (interface{}, sendgrid.RequestError) {
+		return c.DeleteSSOCertificate(fmt.Sprint(d.Id()))
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/sendgrid/resource_sendgrid_sso_integration.go
+++ b/sendgrid/resource_sendgrid_sso_integration.go
@@ -1,0 +1,174 @@
+/*
+Provide a resource to manage SSO integrations. Note that to finalize the integration, a user must click through the 'enable integration' workflow once after supplying all required fields including an SSO certificate via `aws_sso_certificate`.
+Example Usage
+```hcl
+resource "sendgrid_sso_integration" "sso" {
+	name    = "IdP"
+	enabled = false
+
+	signin_url  = "https://idp.com/signin"
+	signout_url = "https://idp.com/signout"
+	entity_id   = "https://idp.com/12345"
+}
+```
+Import
+A SSO integration can be imported, e.g.
+```sh
+$ terraform import sendgrid_sso_integration.sso <integration-id>
+```
+*/
+package sendgrid
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	sendgrid "github.com/trois-six/terraform-provider-sendgrid/sdk"
+)
+
+func resourceSendgridSSOIntegration() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSendgridSSOIntegrationCreate,
+		ReadContext:   resourceSendgridSSOIntegrationRead,
+		UpdateContext: resourceSendgridSSOIntegrationUpdate,
+		DeleteContext: resourceSendgridSSOIntegrationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Description: "The name of the integration.",
+				Required:    true,
+			},
+			"enabled": {
+				Type:        schema.TypeBool,
+				Description: "Indicates if the integration is enabled.",
+				Required:    true,
+			},
+			"signin_url": {
+				Type: schema.TypeString,
+				Description: `The IdP's SAML POST endpoint. This endpoint should receive requests
+					and initiate an SSO login flow. This is called the 'Embed Link' in the Twilio SendGrid UI.`,
+				Optional: true,
+			},
+			"signout_url": {
+				Type: schema.TypeString,
+				Description: `This URL is relevant only for an IdP-initiated authentication flow.
+					If a user authenticates from their IdP, this URL will return them to their IdP when logging out.`,
+				Optional: true,
+			},
+			"entity_id": {
+				Type: schema.TypeString,
+				Description: `An identifier provided by your IdP to identify Twilio SendGrid in the SAML interaction.
+					This is called the 'SAML Issuer ID' in the Twilio SendGrid UI.`,
+				Optional: true,
+			},
+			"completed_integration": {
+				Type:        schema.TypeBool,
+				Description: "Indicates if the integration is complete.",
+				Computed:    true,
+			},
+			"single_signon_url": {
+				Type: schema.TypeString,
+				Description: `The URL where your IdP should POST its SAML response.
+					This is the Twilio SendGrid URL that is responsible for receiving and parsing a SAML assertion.
+					This is the same URL as the Audience URL when using SendGrid.`,
+				Computed: true,
+			},
+			"audience_url": {
+				Type: schema.TypeString,
+				Description: `The URL where your IdP should POST its SAML response.
+					This is the Twilio SendGrid URL that is responsible for receiving and parsing a SAML assertion.
+					This is the same URL as the Single Sign-On URL when using SendGrid.`,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceSendgridSSOIntegrationCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*sendgrid.Client)
+
+	name := d.Get("name").(string)
+	enabled := d.Get("enabled").(bool)
+	signInURL := d.Get("signin_url").(string)
+	signOutURL := d.Get("signout_url").(string)
+	entityID := d.Get("entity_id").(string)
+
+	apiKeyStruct, err := sendgrid.RetryOnRateLimit(ctx, d, func() (interface{}, sendgrid.RequestError) {
+		return c.CreateSSOIntegration(name, enabled, signInURL, signOutURL, entityID)
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	integration := apiKeyStruct.(*sendgrid.SSOIntegration)
+
+	d.SetId(integration.ID)
+
+	return resourceSendgridSSOIntegrationRead(ctx, d, m)
+}
+
+func resourceSendgridSSOIntegrationRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*sendgrid.Client)
+
+	integration, requestErr := c.ReadSSOIntegration(d.Id())
+
+	if requestErr.Err != nil {
+		return diag.FromErr(requestErr.Err)
+	}
+
+	//nolint:errcheck
+	d.Set("name", integration.Name)
+	//nolint:errcheck
+	d.Set("enabled", integration.Enabled)
+	//nolint:errcheck
+	d.Set("signin_url", integration.SignInURL)
+	//nolint:errcheck
+	d.Set("signout_url", integration.SignOutURL)
+	//nolint:errcheck
+	d.Set("entity_id", integration.EntityID)
+	//nolint:errcheck
+	d.Set("completed_integration", integration.CompletedIntegration)
+	//nolint:errcheck
+	d.Set("single_signon_url", integration.SingleSignOnURL)
+	//nolint:errcheck
+	d.Set("audience_url", integration.AudienceURL)
+
+	return nil
+}
+
+func resourceSendgridSSOIntegrationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*sendgrid.Client)
+
+	id := d.Id()
+	name := d.Get("name").(string)
+	enabled := d.Get("enabled").(bool)
+	signInURL := d.Get("signin_url").(string)
+	signOutURL := d.Get("signout_url").(string)
+	entityID := d.Get("entity_id").(string)
+
+	_, err := sendgrid.RetryOnRateLimit(ctx, d, func() (interface{}, sendgrid.RequestError) {
+		return c.UpdateSSOIntegration(id, name, enabled, signInURL, signOutURL, entityID)
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceSendgridSSOIntegrationRead(ctx, d, m)
+}
+
+func resourceSendgridSSOIntegrationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*sendgrid.Client)
+
+	_, err := sendgrid.RetryOnRateLimit(ctx, d, func() (interface{}, sendgrid.RequestError) {
+		return c.DeleteSSOIntegration(d.Id())
+	})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}

--- a/sendgrid/resource_sendgrid_sso_integration.go
+++ b/sendgrid/resource_sendgrid_sso_integration.go
@@ -1,5 +1,8 @@
 /*
-Provide a resource to manage SSO integrations. Note that to finalize the integration, a user must click through the 'enable integration' workflow once after supplying all required fields including an SSO certificate via `aws_sso_certificate`.
+Provide a resource to manage SSO integrations.
+
+**Note** To finalize the integration, a user must click through the 'enable integration'
+workflow once after supplying all required fields including an SSO certificate via `aws_sso_certificate`.
 Example Usage
 ```hcl
 resource "sendgrid_sso_integration" "sso" {


### PR DESCRIPTION
Hello! My team is aiming to use SendGrid's Beta SSO offering and it would be fantastic to have these resources Terraformed if you're open to it.

**Overview**

The PR adds two resources `sendgrid_sso_integration` and `sendgrid_sso_certificate`, which correspond to the [/sso/integrations](https://docs.sendgrid.com/api-reference/single-sign-on-settings/create-an-sso-integration) and [/sso/certificates/](https://docs.sendgrid.com/api-reference/certificates/create-an-sso-certificate) endpoints. These can be used together with an IdP SAML application definition to Terraform the integration.

```hcl

resource "okta_app_saml" "sendgrid" {
  label = "SendGrid"
  ...
}

resource "sendgrid_sso_integration" "sso" {
  name        = "Okta"
  enabled     = true
  entity_id   = okta_app_saml.sendgrid.entity_url
  signin_url  = okta_app_saml.sendgrid.sso_url
  signout_url = okta_app_saml.sendgrid.single_logout_url
}

resource "sendgrid_sso_certificate" "cert" {
  public_certificate = join("\n", ["-----BEGIN CERTIFICATE-----", okta_app_saml.sendgrid.certificate, "-----END CERTIFICATE-----"])
  integration_id     = sendgrid_sso_integration.sso.id
}
```

**Questions**

- Is this a PR you'd be interested in accepting? The SSO feature is currently in Beta, so I would understand if it's too early to adopt for the project. However I'd much rather contribute here than maintain a fork for our team!
- Does the integration test account have access to SSO features? My personal account does not, but my teams account does so I was unsure. If the integration test account has access, I'll add integration tests. 

**Notes**

One thing that doesn't seem to be ironed out in the SendGrid SSO API is that a user must still initially click Enable on the integration to turn it on the first time. Once initially on, the `enable` property on the integration resource will enable/disable the integration as you would expect, but does not seem to affect it initially. This is the case even with all required fields supplied. I've made note of this in the `aws_sso_integration` docs.