### PR TITLE
Fix for non automatic domain authentication dns records

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,12 +1,29 @@
 package main
 
 import (
+	"context"
+	"flag"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/trois-six/terraform-provider-sendgrid/sendgrid"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: sendgrid.Provider,
-	})
+	var debugMode bool
+
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{ProviderFunc: sendgrid.Provider}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "registry.terraform.io/Trois-Six/sendgrid", opts)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		return
+	}
+
+	plugin.Serve(opts)
 }

--- a/sdk/domain_authentication.go
+++ b/sdk/domain_authentication.go
@@ -7,9 +7,12 @@ import (
 )
 
 type DomainAuthenticationDNS struct {
-	MailCNAME DomainAuthenticationDNSValue `json:"mail_cname,omitempty"` //nolint:tagliatelle
-	DKIM1     DomainAuthenticationDNSValue `json:"dkim1,omitempty"`
-	DKIM2     DomainAuthenticationDNSValue `json:"dkim2,omitempty"`
+	MailCNAME    DomainAuthenticationDNSValue `json:"mail_cname,omitempty"` //nolint:tagliatelle
+	DKIM1        DomainAuthenticationDNSValue `json:"dkim1,omitempty"`
+	DKIM2        DomainAuthenticationDNSValue `json:"dkim2,omitempty"`
+	MailServer   DomainAuthenticationDNSValue `json:"mail_server,omitempty"`   //nolint:tagliatelle
+	SubDomainSPF DomainAuthenticationDNSValue `json:"subdomain_spf,omitempty"` //nolint:tagliatelle
+	DKIM         DomainAuthenticationDNSValue `json:"dkim,omitempty"`
 }
 
 type DomainAuthenticationDNSValue struct {
@@ -76,7 +79,7 @@ func (c *Client) CreateDomainAuthentication(
 	if err != nil {
 		return nil, RequestError{
 			StatusCode: http.StatusInternalServerError,
-			Err:        fmt.Errorf("failed creating API key: %w", err),
+			Err:        fmt.Errorf("failed creating domain authentication: %w", err),
 		}
 	}
 

--- a/sdk/domain_authentication_test.go
+++ b/sdk/domain_authentication_test.go
@@ -1,0 +1,78 @@
+package sendgrid
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_parseDomainAuthentication(t *testing.T) {
+	type args struct {
+		respBody string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  *DomainAuthentication
+		want1 RequestError
+	}{
+		{
+			name: "not automatic security",
+			args: args{respBody: `{"id":123,"user_id":234,"subdomain":"aaa","domain":"example.com","username":"user","ips":[],"custom_spf":false,"default":false,"legacy":false,"automatic_security":false,"valid":false,"dns":{"mail_server":{"valid":false,"type":"mx","host":"aaa.example.com","data":"mx.sendgrid.net."},"subdomain_spf":{"valid":false,"type":"txt","host":"bbb.example.com","data":"v=spf1 include:sendgrid.net ~all"},"dkim":{"valid":false,"type":"txt","host":"m1._domainkey.aaa.example.com","data":"k=rsa; t=s; p=ccc"}}}`},
+			want: &DomainAuthentication{
+				ID:                 123,
+				UserID:             234,
+				Domain:             "example.com",
+				Subdomain:          "aaa",
+				Username:           "user",
+				IPs:                []string{},
+				CustomSPF:          false,
+				IsDefault:          false,
+				AutomaticSecurity:  false,
+				CustomDKIMSelector: "",
+				Legacy:             false,
+				Valid:              false,
+				DNS: DomainAuthenticationDNS{
+					MailServer:   DomainAuthenticationDNSValue{Valid: false, Type: "mx", Host: "aaa.example.com", Data: "mx.sendgrid.net."},
+					DKIM:         DomainAuthenticationDNSValue{Valid: false, Type: "txt", Host: "m1._domainkey.aaa.example.com", Data: "k=rsa; t=s; p=ccc"},
+					SubDomainSPF: DomainAuthenticationDNSValue{Valid: false, Type: "txt", Host: "bbb.example.com", Data: "v=spf1 include:sendgrid.net ~all"},
+				},
+			},
+			want1: RequestError{StatusCode: 200, Err: nil},
+		},
+		{
+			name: "automatic security",
+			args: args{respBody: `{"id":123,"user_id":234,"subdomain":"aaa","domain":"example.com","username":"user","ips":[],"custom_spf":false,"default":false,"legacy":false,"automatic_security":true,"valid":false,"dns":{"mail_cname":{"valid":false,"type":"cname","host":"aaa.example.com","data":"u234.abc.sendgrid.net"},"dkim1":{"valid":false,"type":"cname","host":"s1._domainkey.example.com","data":"s1.domainkey.u234.abc.sendgrid.net"},"dkim2":{"valid":false,"type":"cname","host":"s2._domainkey.example.com","data":"s2.domainkey.u234.abc.sendgrid.net"}}}`},
+			want: &DomainAuthentication{
+				ID:                 123,
+				UserID:             234,
+				Domain:             "example.com",
+				Subdomain:          "aaa",
+				Username:           "user",
+				IPs:                []string{},
+				CustomSPF:          false,
+				IsDefault:          false,
+				AutomaticSecurity:  true,
+				CustomDKIMSelector: "",
+				Legacy:             false,
+				Valid:              false,
+				DNS: DomainAuthenticationDNS{
+					MailCNAME: DomainAuthenticationDNSValue{Valid: false, Type: "cname", Host: "aaa.example.com", Data: "u234.abc.sendgrid.net"},
+					DKIM1:     DomainAuthenticationDNSValue{Valid: false, Type: "cname", Host: "s1._domainkey.example.com", Data: "s1.domainkey.u234.abc.sendgrid.net"},
+					DKIM2:     DomainAuthenticationDNSValue{Valid: false, Type: "cname", Host: "s2._domainkey.example.com", Data: "s2.domainkey.u234.abc.sendgrid.net"},
+				},
+			},
+			want1: RequestError{StatusCode: 200, Err: nil},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := parseDomainAuthentication(tt.args.respBody)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseDomainAuthentication() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("parseDomainAuthentication() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}

--- a/sendgrid/resource_sendgrid_domain_authentication.go
+++ b/sendgrid/resource_sendgrid_domain_authentication.go
@@ -231,6 +231,33 @@ func resourceSendgridDomainAuthenticationRead( //nolint:funlen
 		})
 	}
 
+	if auth.DNS.DKIM.Type != "" {
+		dns = append(dns, map[string]interface{}{
+			"type":  auth.DNS.DKIM.Type,
+			"valid": auth.DNS.DKIM.Valid,
+			"host":  auth.DNS.DKIM.Host,
+			"data":  auth.DNS.DKIM.Data,
+		})
+	}
+
+	if auth.DNS.SubDomainSPF.Type != "" {
+		dns = append(dns, map[string]interface{}{
+			"type":  auth.DNS.SubDomainSPF.Type,
+			"valid": auth.DNS.SubDomainSPF.Valid,
+			"host":  auth.DNS.SubDomainSPF.Host,
+			"data":  auth.DNS.SubDomainSPF.Data,
+		})
+	}
+
+	if auth.DNS.MailServer.Type != "" {
+		dns = append(dns, map[string]interface{}{
+			"type":  auth.DNS.MailServer.Type,
+			"valid": auth.DNS.MailServer.Valid,
+			"host":  auth.DNS.MailServer.Host,
+			"data":  auth.DNS.MailServer.Data,
+		})
+	}
+
 	if er := d.Set("dns", dns); er != nil {
 		return diag.FromErr(er)
 	}


### PR DESCRIPTION
If the `automatic_security` attribute of `sendgrid_domain_authentication` is not set then the dns records are not cnames and don't match the existing response format.

e.g.

```
resource "sendgrid_domain_authentication" "default" {
    domain = trimsuffix(google_dns_record_set.a.name, ".")
    # ips = [ "10.10.10.10" ]
    # is_default = true
    # automatic_security = true
}
```

Added tests and extended to handle txt and mx dns records.

Also added debug flag to main to enable debugging with delve.